### PR TITLE
Add test for valid non-string input

### DIFF
--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -96,5 +96,9 @@ describe("parse()", () => {
             espree.parse("foo", Object.freeze({ ecmaFeatures: Object.freeze({}) }));
         });
 
+        it("Cast valid non-string input", () => {
+            espree.parse(Buffer.from("var foo = bar;"));
+        });
+
     });
 });

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -97,7 +97,12 @@ describe("parse()", () => {
         });
 
         it("Cast valid non-string input", () => {
-            espree.parse(Buffer.from("var foo = bar;"));
+            const str = "var foo = bar;";
+
+            assert.deepStrictEqual(
+                espree.parse(Buffer.from(str)),
+                espree.parse(str)
+            );
         });
 
     });


### PR DESCRIPTION
Add test to verify that Buffers and strings produce equal output.